### PR TITLE
Actualizar .gitignore y corregir ruta de volumen en docker-compose.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 .vscode
+data/draft_*.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,6 @@ services:
         max-size: "10m"
         max-file: "5"
     volumes:
-      - ./data/${CATALOG_FILE}:/app/data/catalog.rdf
+      - ./data/${CATALOG_FILE}:/app/data/${CATALOG_FILE}
     restart: on-failure:3
 


### PR DESCRIPTION
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L34-R34): Modified the volume mapping to use the `CATALOG_FILE` environment variable for both the source and target paths.