### PR TITLE
Add GHCR images and update README

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,11 +9,10 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  DOCKERFILE_PATH: easy-rdf-endpoint/Dockerfile.sparql
+  REPOSITORY: ${{ github.repository }}
 
 jobs:
-  build:
+  build-sparql-endpoint:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,32 +37,154 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for Docker
-        id: meta
+      - name: Extract metadata for SPARQL Endpoint image
+        id: meta-sparql
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}
+          flavor: |
+            latest=true
+            prefix=sparql-
+            suffix=
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
           labels: |
-            org.opencontainers.image.title=Easy RDF Endpoint
-            org.opencontainers.image.description=This project provides a simple **Dockerized RDF endpoint** that serves an `.rdf` file an provides an SPARQL Endpoint based on [`vemonet/rdflib-endpoint`](https://github.com/vemonet/rdflib-endpoint)
+            org.opencontainers.image.title=Easy RDF SPARQL Endpoint
+            org.opencontainers.image.description=SPARQL Endpoint based on rdflib-endpoint to query RDF data
             org.opencontainers.image.version={{version}}
 
-      - name: Build and push Docker image
+      - name: Build and push SPARQL Endpoint image
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ${{ env.DOCKERFILE_PATH }}
+          file: easy-rdf-endpoint/Dockerfile.sparql
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-sparql.outputs.tags }}
+          labels: ${{ steps.meta-sparql.outputs.labels }}
 
-      - name: Run Hadolint
+      - name: Run Hadolint on SPARQL Endpoint Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
         with:
-          dockerfile: ${{ env.DOCKERFILE_PATH }}
+          dockerfile: easy-rdf-endpoint/Dockerfile.sparql
+          no-fail: true
+
+  build-validator:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Validator image
+        id: meta-validator
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}
+          flavor: |
+            latest=true
+            prefix=validator-
+            suffix=
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          labels: |
+            org.opencontainers.image.title=RDF Validator
+            org.opencontainers.image.description=RDF Validator with RIOT and SHACL validation for DCAT-AP and DCAT-AP-ES
+            org.opencontainers.image.version={{version}}
+
+      - name: Build and push Validator image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: easy-rdf-endpoint/Dockerfile.validator
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta-validator.outputs.tags }}
+          labels: ${{ steps.meta-validator.outputs.labels }}
+
+      - name: Run Hadolint on Validator Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: easy-rdf-endpoint/Dockerfile.validator
+          no-fail: true
+
+  build-nginx:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for NGINX image
+        id: meta-nginx
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}
+          flavor: |
+            latest=true
+            prefix=nginx-
+            suffix=
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          labels: |
+            org.opencontainers.image.title=Easy RDF NGINX Frontend
+            org.opencontainers.image.description=NGINX frontend for serving RDF and proxying SPARQL and Validator services
+            org.opencontainers.image.version={{version}}
+
+      - name: Build and push NGINX image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: nginx/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta-nginx.outputs.tags }}
+          labels: ${{ steps.meta-nginx.outputs.labels }}
+
+      - name: Run Hadolint on NGINX Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: nginx/Dockerfile
           no-fail: true

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 ## Overview
 This project provides a simple **Dockerized RDF endpoint** that simplifies catalog deployment of `.rdf` files, provides an SPARQL Endpoint based on [`vemonet/rdflib-endpoint`](https://github.com/vemonet/rdflib-endpoint) and incorporates interfaces for both semantic and syntactic validation of RDF files.
 
-About
+> [!TIP]
+> **Quick deployment**: Use our pre-built container images with `docker-compose -f docker-compose.ghcr.yml up -d` to deploy a complete RDF ecosystem in under 5 minutes, without having to build images locally!
+
+# About
 This project provides a simple Dockerized RDF endpoint that simplifies catalog deployment, provides a SPARQL endpoint
 
 * **SPARQL Features**: Advanced RDF Query Capabilities
@@ -49,6 +52,7 @@ Use [Codespaces](https://github.com/features/codespaces) to test `easy-rdf-endpo
 Before starting the deployment, you'll need to set up a `.env` file. This file is crucial as it contains environment variables that the application needs to run properly.
 
 1. Clone project
+
     ```sh
     cd /path/to/my/project
     git clone https://github.com/mjanez/easy-rdf-endpoint.git & cd easy-rdf-endpoint
@@ -56,30 +60,30 @@ Before starting the deployment, you'll need to set up a `.env` file. This file i
 
 2. Place your RDF catalog file in the `./data` folder:
 
-  ```sh
-  # Copy your existing RDF catalog file
-  cp /path/to/your/my_custom_catalog.rdf ./data/
+    ```sh
+    # Copy your existing RDF catalog file
+    cp /path/to/your/my_custom_catalog.rdf ./data/
 
-  # Or create a sample RDF file if you don't have one
-  cat > ./data/my_custom_catalog.rdf << 'EOF'
-  <?xml version="1.0" encoding="utf-8"?>
-  <rdf:RDF
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:dcat="http://www.w3.org/ns/dcat#"
-    xmlns:dct="http://purl.org/dc/terms/">
-    
-    <dcat:Catalog rdf:about="http://example.org/catalog">
-     <dct:title xml:lang="en">Sample Data Catalog</dct:title>
-     <dct:description xml:lang="en">A sample RDF catalog for testing</dct:description>
-     <dct:publisher rdf:resource="http://example.org/publisher"/>
-     <dct:issued>2023-01-01</dct:issued>
-    </dcat:Catalog>
-  </rdf:RDF>
-  EOF
+    # Or create a sample RDF file if you don't have one
+    cat > ./data/my_custom_catalog.rdf << 'EOF'
+    <?xml version="1.0" encoding="utf-8"?>
+    <rdf:RDF
+      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      xmlns:dcat="http://www.w3.org/ns/dcat#"
+      xmlns:dct="http://purl.org/dc/terms/">
+      
+      <dcat:Catalog rdf:about="http://example.org/catalog">
+      <dct:title xml:lang="en">Sample Data Catalog</dct:title>
+      <dct:description xml:lang="en">A sample RDF catalog for testing</dct:description>
+      <dct:publisher rdf:resource="http://example.org/publisher"/>
+      <dct:issued>2023-01-01</dct:issued>
+      </dcat:Catalog>
+    </rdf:RDF>
+    EOF
 
-  # Make sure the file has proper permissions
-  chmod 644 ./data/my_custom_catalog.rdf
-  ```
+    # Make sure the file has proper permissions
+    chmod 644 ./data/my_custom_catalog.rdf
+    ```
 
 3. Copy the [`.env.example`](.env.example) template and modify the resulting `.env` to suit your needs.
 
@@ -116,6 +120,13 @@ Before starting the deployment, you'll need to set up a `.env` file. This file i
 docker compose up -d
 ```
 
+> [!TIP]  
+> **Use pre-built images**: To save time, you can use our pre-built images hosted on GitHub Container Registry:
+> ```sh
+> docker compose -f docker-compose.ghcr.yml up -d
+> ```
+> This approach is faster as it pulls ready-to-use images instead of building them locally!
+
 Then, access your RDF file an [endpoints](#endpoints).
 
 ---
@@ -146,7 +157,7 @@ The endpoints will be available at:
 > - Works with **Codespaces, Docker, Kubernetes, and any containerized environment**.
 
 ### Translation
-After updating the translation file (`messages.po`), don't forget to compile it to generate the `.mo` file, e.g english:
+After updating the translation file (`messages.po`), don't forget to compile it to generate the `.mo` file, e.g English:
 
 ```sh
 cd easy-rdf-endpoint/src/rdf-validator
@@ -154,7 +165,7 @@ cd easy-rdf-endpoint/src/rdf-validator
 # Extract i18n texts and update POT
 xgettext -d messages --from-code=UTF-8 -o locales/messages.pot app.py
 
-# Compile MO files (english)
+# Compile MO files (English)
 msgfmt -o locales/en/LC_MESSAGES/messages.mo locales/en/LC_MESSAGES/messages.po
 ``` 
 

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -1,0 +1,43 @@
+services:
+  nginx:
+    image: ghcr.io/mjanez/easy-rdf-endpoint:nginx-main
+    env_file:
+      - .env
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "10"
+    depends_on:
+      - sparql-endpoint
+    volumes:
+      - ./data/${CATALOG_FILE}:/usr/share/nginx/html/catalog.rdf
+    ports:
+      - "0.0.0.0:${NGINX_PORT_HOST}:80"
+      - "0.0.0.0:${NGINX_SSLPORT_HOST}:443"
+    restart: on-failure:3
+
+  sparql-endpoint:
+    image: ghcr.io/mjanez/easy-rdf-endpoint:sparql-main
+    env_file:
+      - .env
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+    volumes:
+      - ./data/${CATALOG_FILE}:/app/data/${CATALOG_FILE}
+    restart: on-failure:3
+
+  rdf-validator:
+    image: ghcr.io/mjanez/easy-rdf-endpoint:validator-main
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+    volumes:
+      - ./data:/app/data
+      - ./logs:/app/logs
+    restart: on-failure:3


### PR DESCRIPTION
### CI/CD Pipeline Updates:
* **Workflow Restructuring**:
  * Renamed the Docker build job for the SPARQL endpoint and added separate jobs for Validator and NGINX images. (`.github/workflows/docker-build.yml`) [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L12-R15) [[2]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L41-R189)
  * Updated environment variable names and metadata extraction steps to reflect the new job structure. (`.github/workflows/docker-build.yml`) [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L12-R15) [[2]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L41-R189)

### Documentation Enhancements:
* **README Improvements**:
  * Added a quick deployment tip for using pre-built container images with `docker-compose`. (`README.md`)
  * Included a tip for using pre-built images to save time during deployment. (`README.md`)
  * Corrected capitalization in translation instructions. (`README.md`)

### New Configuration Files:
* **Docker Compose for GitHub Container Registry**:
  * Added a new `docker-compose.ghcr.yml` file to facilitate the use of pre-built images from the GitHub Container Registry. (`docker-compose.ghcr.yml`)